### PR TITLE
Adapt to Paw JS API version 0.2.0

### DIFF
--- a/APIBlueprintGenerator.coffee
+++ b/APIBlueprintGenerator.coffee
@@ -1,4 +1,10 @@
-require "mustache.js"
+# in API v0.2.0 and below (Paw 2.2.2 and below), require had no return value
+((root) ->
+  if root.bundle?.minApiVersion('0.2.0')
+    root.Mustache = require("./mustache")
+  else
+    require("mustache.js")
+)(this)
 
 APIBlueprintGenerator = ->
 


### PR DESCRIPTION
@kylef a new version of Paw is coming out very soon, and the `require()` will change its behavior to match the CommonJS style `require()`, this is a quick fix to make it work on both versions