### PR TITLE
Release 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Paw-APIBlueprintGenerator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "devDependencies": {
     "coffee-script": "latest",
     "mkdirp": "~0.5.0",


### PR DESCRIPTION
To encapsulate changes in https://github.com/apiaryio/Paw-APIBlueprintGenerator/pull/13 and to allow the plugin to continue to work in Paw 2.2.3.