### PR TITLE
Feature/add request description

### DIFF
--- a/APIBlueprintGenerator.coffee
+++ b/APIBlueprintGenerator.coffee
@@ -74,6 +74,9 @@ APIBlueprintGenerator = ->
         body_indentation += '    '
       body = body.replace(/^/gm, body_indentation)
 
+    description = paw_request.description
+    has_description = description && description.length > 0
+
     if has_headers || has_body || paw_request.headers['Content-Type']
       return {
         "headers?": has_headers,
@@ -81,7 +84,8 @@ APIBlueprintGenerator = ->
         contentType: paw_request.headers['Content-Type'],
         "body?": has_headers && has_body,
         body: body,
-        description: paw_request.description,
+        "description?": has_description,
+        description: description,
       }
 
   # Get a path from a URL

--- a/APIBlueprintGenerator.coffee
+++ b/APIBlueprintGenerator.coffee
@@ -81,6 +81,7 @@ APIBlueprintGenerator = ->
         contentType: paw_request.headers['Content-Type'],
         "body?": has_headers && has_body,
         body: body,
+        description: paw_request.description,
       }
 
   # Get a path from a URL

--- a/apiblueprint.mustache
+++ b/apiblueprint.mustache
@@ -1,5 +1,7 @@
 # {{{ method }}} {{{ path }}}
 
+{{{request.description}}}
+
 {{#request}}
 + Request{{#contentType}} ({{{contentType}}}){{/contentType}}
 

--- a/apiblueprint.mustache
+++ b/apiblueprint.mustache
@@ -1,8 +1,8 @@
 # {{{ method }}} {{{ path }}}
 
-{{#description?}}
+{{#request.description?}}
 {{{request.description}}}
-{{/description?}}
+{{/request.description?}}
 {{#request}}
 + Request{{#contentType}} ({{{contentType}}}){{/contentType}}
 

--- a/apiblueprint.mustache
+++ b/apiblueprint.mustache
@@ -1,7 +1,8 @@
 # {{{ method }}} {{{ path }}}
 
+{{#description?}}
 {{{request.description}}}
-
+{{/description?}}
 {{#request}}
 + Request{{#contentType}} ({{{contentType}}}){{/contentType}}
 


### PR DESCRIPTION
Paw's Request description is where we can add more information about the request like business rules, explain parameters of the request. Thus, it's an essential item when generating docs from Paw.