### PR TITLE
Unescape the `path` variable

### DIFF
--- a/APIBlueprintGenerator.coffee
+++ b/APIBlueprintGenerator.coffee
@@ -99,7 +99,7 @@ APIBlueprintGenerator = ->
     if !path
       path = '/'
 
-    path
+    unescape(path)
 
   @generate = (context) ->
     paw_request = context.getCurrentRequest()

--- a/APIBlueprintGenerator.js
+++ b/APIBlueprintGenerator.js
@@ -91,7 +91,7 @@
       if (!path) {
         path = '/';
       }
-      return path;
+      return unescape(path);
     };
     this.generate = function(context) {
       var paw_request, template, url;


### PR DESCRIPTION
so that characters like { and } are not escaped to html entities.