### PR TITLE
feat: support exporting all requests

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -27,7 +27,8 @@ build_coffee = (callback) ->
 build_copy = () ->
     fs.writeFileSync "#{ build_dir }/README.md", fs.readFileSync("./README.md")
     fs.writeFileSync "#{ build_dir }/LICENSE", fs.readFileSync("./LICENSE")
-    fs.writeFileSync "#{ build_dir }/apiblueprint.mustache", fs.readFileSync("./apiblueprint.mustache")
+    fs.writeFileSync "#{ build_dir }/apiblueprint-action.mustache", fs.readFileSync("./apiblueprint-action.mustache")
+    fs.writeFileSync "#{ build_dir }/apiblueprint-group.mustache", fs.readFileSync("./apiblueprint-group.mustache")
     fs.writeFileSync "#{ build_dir }/mustache.js", fs.readFileSync("./node_modules/mustache/mustache.js")
 
 # build: build CoffeeScript and copy files to build directory

--- a/apiblueprint-action.mustache
+++ b/apiblueprint-action.mustache
@@ -1,4 +1,9 @@
-# {{{ method }}} {{{ path }}}
+{{#name}}
+{{{ level }}} {{{ name }}} [{{{ method }}} {{{ path }}}]
+{{/name}}
+{{^name}}
+{{{ level }}} {{{ method }}} {{{ path }}}
+{{/name}}
 
 {{#request.description?}}
 {{{request.description}}}

--- a/apiblueprint-group.mustache
+++ b/apiblueprint-group.mustache
@@ -1,0 +1,1 @@
+{{{ level }}} Group {{{ name }}}


### PR DESCRIPTION
When exporting all requests, group them according to the same layout as
defined in Paw.  This implementation was inspired by the
Paw-PostmanCollectionV2Generator [1].

Fixes: Issue #27

[1]: https://github.com/luckymarmot/Paw-PostmanCollectionV2Generator